### PR TITLE
Vijay/DialogComponent

### DIFF
--- a/src/components/Dialogue/Dialog.stories.tsx
+++ b/src/components/Dialogue/Dialog.stories.tsx
@@ -30,7 +30,7 @@ function SimpleDialogBody(props: SimpleDialogProps) {
   };
 
   return (
-    <Dialog onClose={handleClose} open={open}>
+    <Dialog onClose={handleClose} open={open} className="dialog">
       <DialogTitle>Set backup account</DialogTitle>
       <div>
       {emails.map((email) =>
@@ -131,7 +131,7 @@ export const FormDialog = () => {
       <Button onClick={handleClickOpen}>
         Open form dialog
       </Button>
-      <Dialog open={open} onClose={handleClose}>
+      <Dialog open={open} onClose={handleClose} disableEscapeKeyDown={false}>
         <DialogTitle>Subscribe</DialogTitle>
         <DialogContent>
           To subscribe to this website, please enter your email address here. We

--- a/src/components/Dialogue/Dialog.stories.tsx
+++ b/src/components/Dialogue/Dialog.stories.tsx
@@ -138,7 +138,7 @@ export const FormDialog = () => {
           will send updates occasionally.
           <Input />
         </DialogContent>
-        <DialogActions>
+        <DialogActions disableSpacing={true}>
           <Button onClick={handleClose}>Cancel</Button>
           <Button onClick={handleClose}>Subscribe</Button>
         </DialogActions>

--- a/src/components/Dialogue/Dialog.stories.tsx
+++ b/src/components/Dialogue/Dialog.stories.tsx
@@ -30,13 +30,13 @@ function SimpleDialogBody(props: SimpleDialogProps) {
   };
 
   return (
-    <Dialog onClose={handleClose} open={open} className="dialog">
+    <Dialog onClose={handleClose} open={open}>
       <DialogTitle>Set backup account</DialogTitle>
       <div>
       {emails.map((email) =>
-          <div>
-          <Icon name='plus' size='small' />
-          <div>{email}</div>
+          <div style={{display:'flex', gap: '10px'}}>
+            <Icon name='plus' size='small' />
+            <span>{email}</span>
           </div>)}
         <div>Add Account</div>  
       </div>
@@ -83,7 +83,7 @@ export const AlertDialog = () => {
   };
 
   return (
-    <div>
+    <>
       <Button onClick={handleClickOpen}>
         Open alert dialog
       </Button>
@@ -92,9 +92,10 @@ export const AlertDialog = () => {
         onClose={handleClose}
         aria-labelledby="alert-dialog-title"
         aria-describedby="alert-dialog-description"
+        fullScreen={true}
       >
         <DialogTitle id="alert-dialog-title">
-          {"Use Google's location service?"}
+          Use Google's location service?
         </DialogTitle>
         <DialogContent>
           <DialogContentText id="alert-dialog-description">
@@ -104,12 +105,12 @@ export const AlertDialog = () => {
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Disagree</Button>
-          <Button onClick={handleClose} autoFocus>
+          <Button onClick={handleClose}>
             Agree
           </Button>
         </DialogActions> 
       </Dialog>
-    </div>
+    </>
   );
 }
 

--- a/src/components/Dialogue/Dialog.stories.tsx
+++ b/src/components/Dialogue/Dialog.stories.tsx
@@ -8,7 +8,7 @@ import DialogActions from './DialogActions';
 import Icon from '../Icon';
 import Button from '../Button';
 import Input from '../Input';
-import { CloseDialogReason } from './Dialog';
+import { DialogCloseReason } from './Dialog';
 export default {
   title: 'Dialogue',
   component: Dialog,
@@ -133,7 +133,7 @@ export const FormDialog = () => {
       </Button>
       <Dialog open={open} onClose={handleClose} disableEscapeKeyDown={false}>
         <DialogTitle>Subscribe</DialogTitle>
-        <DialogContent>
+        <DialogContent dividers={true}>
           To subscribe to this website, please enter your email address here. We
             will send updates occasionally.
           <Input />

--- a/src/components/Dialogue/Dialog.stories.tsx
+++ b/src/components/Dialogue/Dialog.stories.tsx
@@ -3,7 +3,9 @@ import { action } from '@storybook/addon-actions';
 import Dialog from './Dialog';
 import DialogTitle from './DialogTitle';
 import DialogContent from './DialogContent';
+import DialogContentText from './DialogContentText';
 import DialogActions from './DialogActions';
+import Icon from '../Icon';
 import Button from '../Button';
 import Input from '../Input';
 import { CloseDialogReason } from './Dialog';
@@ -32,7 +34,10 @@ function SimpleDialogBody(props: SimpleDialogProps) {
       <DialogTitle>Set backup account</DialogTitle>
       <div>
       {emails.map((email) =>
-          <div>{email}</div>)}
+          <div>
+          <Icon name='plus' size='small' />
+          <div>{email}</div>
+          </div>)}
         <div>Add Account</div>  
       </div>
     </Dialog>
@@ -68,10 +73,12 @@ export const AlertDialog = () => {
   const [open, setOpen] = React.useState(false);
 
   const handleClickOpen = () => {
+    action('opening dialog box!')();
     setOpen(true);
   };
 
   const handleClose = () => {
+    action('closing dialog box!')();
     setOpen(false);
   };
 
@@ -90,12 +97,6 @@ export const AlertDialog = () => {
           {"Use Google's location service?"}
         </DialogTitle>
         <DialogContent>
-          
-            Let Google help apps determine location. This means sending anonymous
-            location data to Google, even when no apps are running.
-          
-        </DialogContent>
-        {/*<DialogContent>
           <DialogContentText id="alert-dialog-description">
             Let Google help apps determine location. This means sending anonymous
             location data to Google, even when no apps are running.
@@ -106,7 +107,7 @@ export const AlertDialog = () => {
           <Button onClick={handleClose} autoFocus>
             Agree
           </Button>
-        </DialogActions> */}
+        </DialogActions> 
       </Dialog>
     </div>
   );
@@ -116,10 +117,12 @@ export const FormDialog = () => {
   const [open, setOpen] = useState(false);
 
   const handleClickOpen = () => {
+    action('opening dialog box!')();
     setOpen(true);
   };
 
   const handleClose = () => {
+    action('closing dialog box!')();
     setOpen(false);
   };
 

--- a/src/components/Dialogue/Dialog.stories.tsx
+++ b/src/components/Dialogue/Dialog.stories.tsx
@@ -1,34 +1,145 @@
-import React from 'react';
+import React, { useState} from 'react';
 import { action } from '@storybook/addon-actions';
 import Dialog from './Dialog';
-
+import DialogTitle from './DialogTitle';
+import DialogContent from './DialogContent';
+import DialogActions from './DialogActions';
+import Button from '../Button';
+import Input from '../Input';
+import { CloseDialogReason } from './Dialog';
 export default {
   title: 'Dialogue',
   component: Dialog,
 };
+interface SimpleDialogProps {
+  open: boolean;
+  selectedValue: string;
+  onClose: (value: string) => void;
+}
+function SimpleDialogBody(props: SimpleDialogProps) {
+  const { onClose, open, selectedValue } = props;
+  const emails = ['username@gmail.com', 'user02@gmail.com'];
+  const handleClose = () => {
+    onClose(selectedValue);
+  };
 
-const buttonStyle: React.CSSProperties = {
-  marginRight: '5px',
-  marginTop: '5px',
-};
+  const handleListItemClick = (value: string) => {
+    onClose(value);
+  };
 
-export const SimpleDialog = () => (
-  <>
-    <button>Open Dialog</button>
-    <Dialog>
-      <div>Simple Dialog</div>
+  return (
+    <Dialog onClose={handleClose} open={open}>
+      <DialogTitle>Set backup account</DialogTitle>
+      <div>
+      {emails.map((email) =>
+          <div>{email}</div>)}
+        <div>Add Account</div>  
+      </div>
     </Dialog>
-  </>
-);
+  );
+}
+export const SimpleDialog = ()=>{
+  const emails = ['username@gmail.com', 'user02@gmail.com'];
+  const [open, setOpen] = useState(false);
+  const [selectedValue, setSelectedValue] = useState(emails[1]);
+   const handleClickOpen = () => {
+    setOpen(true);
+  };
 
-export const AlertDialog = () => (
-  <Dialog>
-    <div>Alert Dialog</div>
-  </Dialog>
-);
+  const handleClose = (value: string) => {
+    setOpen(false);
+    setSelectedValue(value);
+  };
+  return (
+    <>
+      <Button onClick={handleClickOpen}>
+        Open simple dialog
+      </Button>
+      <SimpleDialogBody
+        selectedValue={selectedValue}
+        open={open}
+        onClose={handleClose}
+      />
+    </>
+    )
+}
 
-export const FormDialog = () => (
-  <Dialog>
-    <div>Form Dialog</div>
-  </Dialog>
-);
+export const AlertDialog = () => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <Button onClick={handleClickOpen}>
+        Open alert dialog
+      </Button>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          {"Use Google's location service?"}
+        </DialogTitle>
+        <DialogContent>
+          
+            Let Google help apps determine location. This means sending anonymous
+            location data to Google, even when no apps are running.
+          
+        </DialogContent>
+        {/*<DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            Let Google help apps determine location. This means sending anonymous
+            location data to Google, even when no apps are running.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Disagree</Button>
+          <Button onClick={handleClose} autoFocus>
+            Agree
+          </Button>
+        </DialogActions> */}
+      </Dialog>
+    </div>
+  );
+}
+
+export const FormDialog = () => {
+  const [open, setOpen] = useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <div>
+      <Button onClick={handleClickOpen}>
+        Open form dialog
+      </Button>
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle>Subscribe</DialogTitle>
+        <DialogContent>
+          To subscribe to this website, please enter your email address here. We
+            will send updates occasionally.
+          <Input />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleClose}>Subscribe</Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/Dialogue/Dialog.stories.tsx
+++ b/src/components/Dialogue/Dialog.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState} from 'react';
+import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import Dialog from './Dialog';
 import DialogTitle from './DialogTitle';
@@ -33,21 +33,22 @@ function SimpleDialogBody(props: SimpleDialogProps) {
     <Dialog onClose={handleClose} open={open}>
       <DialogTitle>Set backup account</DialogTitle>
       <div>
-      {emails.map((email) =>
-          <div style={{display:'flex', gap: '10px'}}>
-            <Icon name='plus' size='small' />
+        {emails.map((email) => (
+          <div style={{ display: 'flex', gap: '10px' }}>
+            <Icon name="plus" size="small" />
             <span>{email}</span>
-          </div>)}
-        <div>Add Account</div>  
+          </div>
+        ))}
+        <div>Add Account</div>
       </div>
     </Dialog>
   );
 }
-export const SimpleDialog = ()=>{
+export const SimpleDialog = () => {
   const emails = ['username@gmail.com', 'user02@gmail.com'];
   const [open, setOpen] = useState(false);
   const [selectedValue, setSelectedValue] = useState(emails[1]);
-   const handleClickOpen = () => {
+  const handleClickOpen = () => {
     setOpen(true);
   };
 
@@ -57,17 +58,15 @@ export const SimpleDialog = ()=>{
   };
   return (
     <>
-      <Button onClick={handleClickOpen}>
-        Open simple dialog
-      </Button>
+      <Button onClick={handleClickOpen}>Open simple dialog</Button>
       <SimpleDialogBody
         selectedValue={selectedValue}
         open={open}
         onClose={handleClose}
       />
     </>
-    )
-}
+  );
+};
 
 export const AlertDialog = () => {
   const [open, setOpen] = React.useState(false);
@@ -84,35 +83,32 @@ export const AlertDialog = () => {
 
   return (
     <>
-      <Button onClick={handleClickOpen}>
-        Open alert dialog
-      </Button>
+      <Button onClick={handleClickOpen}>Open alert dialog</Button>
       <Dialog
         open={open}
         onClose={handleClose}
         aria-labelledby="alert-dialog-title"
         aria-describedby="alert-dialog-description"
         fullScreen={true}
+        maxWidth="xl"
       >
         <DialogTitle id="alert-dialog-title">
           Use Google's location service?
         </DialogTitle>
         <DialogContent>
           <DialogContentText id="alert-dialog-description">
-            Let Google help apps determine location. This means sending anonymous
-            location data to Google, even when no apps are running.
+            Let Google help apps determine location. This means sending
+            anonymous location data to Google, even when no apps are running.
           </DialogContentText>
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Disagree</Button>
-          <Button onClick={handleClose}>
-            Agree
-          </Button>
-        </DialogActions> 
+          <Button onClick={handleClose}>Agree</Button>
+        </DialogActions>
       </Dialog>
     </>
   );
-}
+};
 
 export const FormDialog = () => {
   const [open, setOpen] = useState(false);
@@ -129,14 +125,17 @@ export const FormDialog = () => {
 
   return (
     <div>
-      <Button onClick={handleClickOpen}>
-        Open form dialog
-      </Button>
-      <Dialog open={open} onClose={handleClose} disableEscapeKeyDown={false}>
+      <Button onClick={handleClickOpen}>Open form dialog</Button>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        disableEscapeKeyDown={false}
+        maxWidth={false}
+      >
         <DialogTitle>Subscribe</DialogTitle>
         <DialogContent dividers={true}>
           To subscribe to this website, please enter your email address here. We
-            will send updates occasionally.
+          will send updates occasionally.
           <Input />
         </DialogContent>
         <DialogActions>
@@ -146,4 +145,4 @@ export const FormDialog = () => {
       </Dialog>
     </div>
   );
-}
+};

--- a/src/components/Dialogue/Dialog.stories.tsx
+++ b/src/components/Dialogue/Dialog.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import Dialog from './Dialog';
+
+export default {
+  title: 'Dialogue',
+  component: Dialog,
+};
+
+const buttonStyle: React.CSSProperties = {
+  marginRight: '5px',
+  marginTop: '5px',
+};
+
+export const SimpleDialog = () => (
+  <>
+    <button>Open Dialog</button>
+    <Dialog>
+      <div>Simple Dialog</div>
+    </Dialog>
+  </>
+);
+
+export const AlertDialog = () => (
+  <Dialog>
+    <div>Alert Dialog</div>
+  </Dialog>
+);
+
+export const FormDialog = () => (
+  <Dialog>
+    <div>Form Dialog</div>
+  </Dialog>
+);

--- a/src/components/Dialogue/Dialog.test.tsx
+++ b/src/components/Dialogue/Dialog.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { render, fireEvent } from '@testing-library/react';
+import Dialog, { PatDialogProps } from './Dialog';
+
+describe('Dialog Component', () => {
+  it('should match snapshot', () => {
+    const { asFragment } = render(<Dialog> Snapshot Button </Dialog>);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render Basic Dialog, Alert Dialog or Form Dialog depending on the different', () => {});
+  it('should render disabled button', () => {});
+  it('should be possible to provide title, content, actions of the dialog component from children props of the component', () => {});
+  it('should have a dimed backdrop by default, users can close the dialog by clicking on the backdrop', () => {});
+});
+describe('Users of Dialog Component', () => {
+  it('should not be able to scroll the page when the dialog is open', () => {});
+  it('should be able to listen to the close of the dialog by providing the onClose callback function.', () => {});
+  it('should be able to control the open/close of the dialog from props.', () => {});
+});

--- a/src/components/Dialogue/Dialog.test.tsx
+++ b/src/components/Dialogue/Dialog.test.tsx
@@ -6,11 +6,10 @@ import DialogContentText from './DialogContentText';
 import DialogActions from './DialogActions';
 import DialogTitle from './DialogTitle';
 
-
 describe('Dialog Component and sub-components', () => {
   it('should match snapshot', () => {
     const { asFragment } = render(
-      <Dialog>
+      <Dialog open={true} onClose={() => {}}>
         <DialogTitle>Dialog Title</DialogTitle>
         <DialogContent>
           <DialogContentText>Content Text</DialogContentText>
@@ -20,218 +19,278 @@ describe('Dialog Component and sub-components', () => {
           <button>Button 1</button>
           <button>Button 2</button>
         </DialogActions>
-      </Dialog>);
+      </Dialog>
+    );
     expect(asFragment()).toMatchSnapshot();
   });
-  it('should not render Dialog Component and sub-components when open is false', ()=>{
+  it('should not render Dialog Component and sub-components when open is false', () => {
     const dialog = render(
-      <Dialog open={false} onClose={()=>{}}>
-          Dialog
-          <DialogTitle>Title</DialogTitle>
-          <DialogContent>
-            <DialogContentText>Content Text</DialogContentText>
-            <div>Content</div>
-          </DialogContent>
-          <DialogActions>
-            <button>Button 1</button>
-            <button>Button 2</button>
-          </DialogActions>
+      <Dialog open={false} onClose={() => {}}>
+        Dialog
+        <DialogTitle>Title</DialogTitle>
+        <DialogContent>
+          <DialogContentText>Content Text</DialogContentText>
+          <div>Content</div>
+        </DialogContent>
+        <DialogActions>
+          <button>Button 1</button>
+          <button>Button 2</button>
+        </DialogActions>
       </Dialog>
-      );
-    
-    expect(dialog.queryByTestId('dialog-element') as HTMLElement).not.toBeInTheDocument();
-    expect(screen.queryByTestId('dialog-title-element') as HTMLElement).not.toBeInTheDocument();
-    expect(dialog.queryByTestId('dialog-body-element') as HTMLElement).not.toBeInTheDocument();
-    expect(dialog.queryByTestId('dialog-actions-element') as HTMLElement).not.toBeInTheDocument();
-    expect(dialog.queryByTestId('dialog-content-element') as HTMLElement).not.toBeInTheDocument();
-    expect(dialog.queryByTestId('dialog-contenttext-element') as HTMLElement).not.toBeInTheDocument();
+    );
+
+    expect(
+      dialog.queryByTestId('dialog-element') as HTMLElement
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('dialog-title-element') as HTMLElement
+    ).not.toBeInTheDocument();
+    expect(
+      dialog.queryByTestId('dialog-body-element') as HTMLElement
+    ).not.toBeInTheDocument();
+    expect(
+      dialog.queryByTestId('dialog-actions-element') as HTMLElement
+    ).not.toBeInTheDocument();
+    expect(
+      dialog.queryByTestId('dialog-content-element') as HTMLElement
+    ).not.toBeInTheDocument();
+    expect(
+      dialog.queryByTestId('dialog-contenttext-element') as HTMLElement
+    ).not.toBeInTheDocument();
     expect(dialog.queryByText('Dialog') as HTMLElement).not.toBeInTheDocument();
     expect(screen.queryByText('Title') as HTMLElement).not.toBeInTheDocument();
-    expect(screen.queryByText('Content Text') as HTMLElement).not.toBeInTheDocument();
-    expect(screen.queryByText('Content') as HTMLElement).not.toBeInTheDocument();
-    expect(screen.queryByText('Button 1') as HTMLElement).not.toBeInTheDocument();
-    expect(screen.queryByText('Button 2') as HTMLElement).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Content Text') as HTMLElement
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Content') as HTMLElement
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Button 1') as HTMLElement
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Button 2') as HTMLElement
+    ).not.toBeInTheDocument();
   });
-  it('should render Dialog Component and sub-components when open is true', ()=>{
+  it('should render Dialog Component and sub-components when open is true', () => {
     const dialog = render(
-      <Dialog open={true} onClose={()=>{}}>
-          Dialog
-          <DialogTitle>Title</DialogTitle>
-          <DialogContent>
-            <DialogContentText>Content Text</DialogContentText>
-            <div>Content</div>
-          </DialogContent>
-          <DialogActions>
-            <button>Button 1</button>
-            <button>Button 2</button>
-          </DialogActions>
+      <Dialog open={true} onClose={() => {}}>
+        Dialog
+        <DialogTitle>Title</DialogTitle>
+        <DialogContent>
+          <DialogContentText>Content Text</DialogContentText>
+          <div>Content</div>
+        </DialogContent>
+        <DialogActions>
+          <button>Button 1</button>
+          <button>Button 2</button>
+        </DialogActions>
       </Dialog>
-      );
-    
-    expect(dialog.queryByTestId('dialog-element') as HTMLElement).toBeInTheDocument();
-    expect(screen.queryByTestId('dialog-title-element') as HTMLElement).toBeInTheDocument();
-    expect(dialog.queryByTestId('dialog-body-element') as HTMLElement).toBeInTheDocument();
-    expect(dialog.queryByTestId('dialog-actions-element') as HTMLElement).toBeInTheDocument();
-    expect(dialog.queryByTestId('dialog-content-element') as HTMLElement).toBeInTheDocument();
-    expect(dialog.queryByTestId('dialog-contenttext-element') as HTMLElement).toBeInTheDocument();
+    );
+
+    expect(
+      dialog.queryByTestId('dialog-element') as HTMLElement
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('dialog-title-element') as HTMLElement
+    ).toBeInTheDocument();
+    expect(
+      dialog.queryByTestId('dialog-body-element') as HTMLElement
+    ).toBeInTheDocument();
+    expect(
+      dialog.queryByTestId('dialog-actions-element') as HTMLElement
+    ).toBeInTheDocument();
+    expect(
+      dialog.queryByTestId('dialog-content-element') as HTMLElement
+    ).toBeInTheDocument();
+    expect(
+      dialog.queryByTestId('dialog-contenttext-element') as HTMLElement
+    ).toBeInTheDocument();
     expect(dialog.queryByText('Dialog') as HTMLElement).toBeInTheDocument();
     expect(screen.queryByText('Title') as HTMLElement).toBeInTheDocument();
-    expect(screen.queryByText('Content Text') as HTMLElement).toBeInTheDocument();
+    expect(
+      screen.queryByText('Content Text') as HTMLElement
+    ).toBeInTheDocument();
     expect(screen.queryByText('Content') as HTMLElement).toBeInTheDocument();
     expect(screen.queryByText('Button 1') as HTMLElement).toBeInTheDocument();
     expect(screen.queryByText('Button 2') as HTMLElement).toBeInTheDocument();
   });
-  it('should render Dialog Title Component as per props', ()=>{
+  it('should render Dialog Title Component as per props', () => {
     const dialogTitleComponent = render(
       <DialogTitle className="class1 class2">Dialog Title</DialogTitle>
-      );
-    const dialogTitleElement = dialogTitleComponent.queryByText('Dialog Title') as HTMLElement;
+    );
+    const dialogTitleElement = dialogTitleComponent.queryByText(
+      'Dialog Title'
+    ) as HTMLElement;
     expect(dialogTitleElement).toBeInTheDocument();
     expect(dialogTitleElement).toHaveClass('dialog__title');
-    expect(screen.queryByText('Dialog Title') as HTMLElement).toBeInTheDocument();
-    expect(screen.queryByText('Dialog Title') as HTMLElement).toHaveClass('dialog__title');
+    expect(
+      screen.queryByText('Dialog Title') as HTMLElement
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Dialog Title') as HTMLElement).toHaveClass(
+      'dialog__title'
+    );
     /* checking if additional classes are present in rendered component */
-    expect(screen.queryByText('Dialog Title') as HTMLElement).toHaveClass('class1');
-    expect(screen.queryByText('Dialog Title') as HTMLElement).toHaveClass('class2');
-    expect(screen.queryByText('Dialog Title 1') as HTMLElement).not.toBeInTheDocument();
+    expect(screen.queryByText('Dialog Title') as HTMLElement).toHaveClass(
+      'class1'
+    );
+    expect(screen.queryByText('Dialog Title') as HTMLElement).toHaveClass(
+      'class2'
+    );
+    expect(
+      screen.queryByText('Dialog Title 1') as HTMLElement
+    ).not.toBeInTheDocument();
   });
-  
-  it('should render DialogContent component as per props', ()=>{
+
+  it('should render DialogContent component as per props', () => {
     const component = render(
-      <DialogContent className="class1 class2">
-      Dialog Content
-      </DialogContent>
-      );
+      <DialogContent className="class1 class2">Dialog Content</DialogContent>
+    );
     const element = component.queryByText('Dialog Content') as HTMLElement;
     expect(element).toBeInTheDocument();
     expect(element).toHaveClass('dialog__content');
-    expect(screen.queryByText('Dialog Content') as HTMLElement).toBeInTheDocument();
-    expect(screen.queryByText('Dialog Content') as HTMLElement).toHaveClass('dialog__content');
+    expect(
+      screen.queryByText('Dialog Content') as HTMLElement
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Dialog Content') as HTMLElement).toHaveClass(
+      'dialog__content'
+    );
     /* checking if additional classes are present in rendered component */
-    expect(screen.queryByText('Dialog Content') as HTMLElement).toHaveClass('class1');
-    expect(screen.queryByText('Dialog Content') as HTMLElement).toHaveClass('class2');
-    expect(screen.queryByText('Dialog Content 1') as HTMLElement).not.toBeInTheDocument(); 
+    expect(screen.queryByText('Dialog Content') as HTMLElement).toHaveClass(
+      'class1'
+    );
+    expect(screen.queryByText('Dialog Content') as HTMLElement).toHaveClass(
+      'class2'
+    );
+    expect(
+      screen.queryByText('Dialog Content 1') as HTMLElement
+    ).not.toBeInTheDocument();
   });
-  it('should render DialogContentText component as per props', ()=>{
+  it('should render DialogContentText component as per props', () => {
     const component = render(
-      <DialogContentText className='class1 class2'>Dialog Content Text
+      <DialogContentText className="class1 class2">
+        Dialog Content Text
       </DialogContentText>
-      );
+    );
     const element = component.queryByText('Dialog Content Text') as HTMLElement;
     expect(element).toBeInTheDocument();
     expect(element).toHaveClass('dialog__content-text');
-    expect(screen.queryByText('Dialog Content Text') as HTMLElement).toBeInTheDocument();
-    expect(screen.queryByText('Dialog Content Text') as HTMLElement).toHaveClass('dialog__content-text');
+    expect(
+      screen.queryByText('Dialog Content Text') as HTMLElement
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Dialog Content Text') as HTMLElement
+    ).toHaveClass('dialog__content-text');
     /* checking if additional classes are present in rendered component */
-    expect(screen.queryByText('Dialog Content Text') as HTMLElement).toHaveClass('class1');
-    expect(screen.queryByText('Dialog Content Text') as HTMLElement).toHaveClass('class2');
-    expect(screen.queryByText('Dialog Content Text 1') as HTMLElement).not.toBeInTheDocument(); 
+    expect(
+      screen.queryByText('Dialog Content Text') as HTMLElement
+    ).toHaveClass('class1');
+    expect(
+      screen.queryByText('Dialog Content Text') as HTMLElement
+    ).toHaveClass('class2');
+    expect(
+      screen.queryByText('Dialog Content Text 1') as HTMLElement
+    ).not.toBeInTheDocument();
   });
-  it('should render DialogActions component', ()=>{
+  it('should render DialogActions component', () => {
     const component = render(
-      <DialogActions className='class1 class2'>
-        Dialog Actions
-      </DialogActions>
-      );
+      <DialogActions className="class1 class2">Dialog Actions</DialogActions>
+    );
     const element = component.queryByText('Dialog Actions') as HTMLElement;
     expect(element).toBeInTheDocument();
     expect(element).toHaveClass('dialog__actions');
-    expect(screen.queryByText('Dialog Actions') as HTMLElement).toBeInTheDocument();
-    expect(screen.queryByText('Dialog Actions') as HTMLElement).toHaveClass('dialog__actions');
+    expect(
+      screen.queryByText('Dialog Actions') as HTMLElement
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Dialog Actions') as HTMLElement).toHaveClass(
+      'dialog__actions'
+    );
     /* checking if additional classes are present in rendered component */
-    expect(screen.queryByText('Dialog Actions') as HTMLElement).toHaveClass('class1');
-    expect(screen.queryByText('Dialog Actions') as HTMLElement).toHaveClass('class2');
-    expect(screen.queryByText('Dialog Actions 1') as HTMLElement).not.toBeInTheDocument(); 
-  });  
-  
-  it('should have a dimed backdrop by default, users can close the dialog by clicking on the backdrop', () => {
-    const dialog = render(
-      <Dialog open={true} onClose={()=>{}}>
-          Dialog
-          <DialogTitle>Title</DialogTitle>
-          <DialogContent>
-            <DialogContentText>Content Text</DialogContentText>
-            <div>Content</div>
-          </DialogContent>
-          <DialogActions>
-            <button>Button 1</button>
-            <button>Button 2</button>
-          </DialogActions>
-      </Dialog>
-      );
-    expect(dialog.getByTestId('dialog-element').style.opacity).toBe("0.5");
+    expect(screen.queryByText('Dialog Actions') as HTMLElement).toHaveClass(
+      'class1'
+    );
+    expect(screen.queryByText('Dialog Actions') as HTMLElement).toHaveClass(
+      'class2'
+    );
+    expect(
+      screen.queryByText('Dialog Actions 1') as HTMLElement
+    ).not.toBeInTheDocument();
   });
 });
 describe('Users of Dialog Component', () => {
   it('should not be able to scroll the page when the dialog is open', () => {
     const dialog = render(
-      <Dialog open={true} onClose={()=>{}}>
-          Dialog
-          <DialogTitle>Title</DialogTitle>
-          <DialogContent>
-            <DialogContentText>Content Text</DialogContentText>
-            <div>Content</div>
-          </DialogContent>
-          <DialogActions>
-            <button>Button 1</button>
-            <button>Button 2</button>
-          </DialogActions>
+      <Dialog open={true} onClose={() => {}}>
+        Dialog
+        <DialogTitle>Title</DialogTitle>
+        <DialogContent>
+          <DialogContentText>Content Text</DialogContentText>
+          <div>Content</div>
+        </DialogContent>
+        <DialogActions>
+          <button>Button 1</button>
+          <button>Button 2</button>
+        </DialogActions>
       </Dialog>
-      );
-    expect(dialog.queryByTestId('dialog-element') as HTMLElement).toBeInTheDocument();
+    );
+    expect(
+      dialog.queryByTestId('dialog-element') as HTMLElement
+    ).toBeInTheDocument();
     expect(document.body.style.overflow).toBe('hidden');
   });
   it('should be able to scroll the page when the dialog is closed', () => {
     const dialog = render(
-      <Dialog open={false} onClose={()=>{}}>
-          Dialog
-          <DialogTitle>Title</DialogTitle>
-          <DialogContent>
-            <DialogContentText>Content Text</DialogContentText>
-            <div>Content</div>
-          </DialogContent>
-          <DialogActions>
-            <button>Button 1</button>
-            <button>Button 2</button>
-          </DialogActions>
+      <Dialog open={false} onClose={() => {}}>
+        Dialog
+        <DialogTitle>Title</DialogTitle>
+        <DialogContent>
+          <DialogContentText>Content Text</DialogContentText>
+          <div>Content</div>
+        </DialogContent>
+        <DialogActions>
+          <button>Button 1</button>
+          <button>Button 2</button>
+        </DialogActions>
       </Dialog>
-      );
-    expect(dialog.queryByTestId('dialog-element') as HTMLElement).not.toBeInTheDocument();
+    );
+    expect(
+      dialog.queryByTestId('dialog-element') as HTMLElement
+    ).not.toBeInTheDocument();
     expect(document.body.style.overflow).not.toBe('hidden');
   });
   it('should be able to listen to the close of the dialog by providing the onClose callback function.', () => {
-    const onCloseHandler = jest.fn((event, reason)=>{});
+    const onCloseHandler = jest.fn((event, reason) => {});
     const component = render(
       <Dialog open={true} onClose={onCloseHandler}>
         <div>Dialog</div>
-      </Dialog>);
-    
+      </Dialog>
+    );
+
     /* checking if onClose is triggered on backdrop click*/
     const backDrop = component.getByTestId('dialog-element');
     expect(onCloseHandler).toHaveBeenCalledTimes(0);
     fireEvent.click(backDrop);
     expect(onCloseHandler).toHaveBeenCalledTimes(1);
-    
+
     /* checkign if onClose is not triggered when clicked on dialog body (not backdrop) */
     const dialogBody = component.getByTestId('dialog-body-element');
     fireEvent.click(dialogBody);
     expect(onCloseHandler).toHaveBeenCalledTimes(1);
-
   });
-  it('should be able to listen to close of dialog by escape key down event by default', ()=>{
-    const onCloseHandler = jest.fn((event, reason)=>{});
+  it('should be able to listen to close of dialog by escape key down event by default', () => {
+    const onCloseHandler = jest.fn((event, reason) => {});
     const component = render(
       <Dialog open={true} onClose={onCloseHandler}>
         <div>Dialog</div>
-      </Dialog>);
+      </Dialog>
+    );
     expect(onCloseHandler).toHaveBeenCalledTimes(0);
     fireEvent.keyDown(document, {
-      key: "Escape",
-      code: "Escape",
+      key: 'Escape',
+      code: 'Escape',
       keyCode: 27,
-      charCode: 27
+      charCode: 27,
     });
     expect(onCloseHandler).toHaveBeenCalledTimes(1);
-  })
-  
+  });
 });

--- a/src/components/Dialogue/Dialog.test.tsx
+++ b/src/components/Dialogue/Dialog.test.tsx
@@ -1,21 +1,192 @@
 import React from 'react';
-
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import Dialog, { PatDialogProps } from './Dialog';
+import DialogContent from './DialogContent';
+import DialogContentText from './DialogContentText';
+import DialogActions from './DialogActions';
+import DialogTitle from './DialogTitle';
 
-describe('Dialog Component', () => {
+
+describe('Dialog Component and sub-components', () => {
   it('should match snapshot', () => {
-    const { asFragment } = render(<Dialog> Snapshot Button </Dialog>);
+    const { asFragment } = render(
+      <Dialog>
+        <DialogTitle>Dialog Title</DialogTitle>
+        <DialogContent>
+          <DialogContentText>Content Text</DialogContentText>
+          <div>Content</div>
+        </DialogContent>
+        <DialogActions>
+          <button>Button 1</button>
+          <button>Button 2</button>
+        </DialogActions>
+      </Dialog>);
     expect(asFragment()).toMatchSnapshot();
   });
-
-  it('should render Basic Dialog, Alert Dialog or Form Dialog depending on the different', () => {});
-  it('should render disabled button', () => {});
-  it('should be possible to provide title, content, actions of the dialog component from children props of the component', () => {});
-  it('should have a dimed backdrop by default, users can close the dialog by clicking on the backdrop', () => {});
+  it('should not render Dialog Component and sub-components when open is false', ()=>{
+    const dialog = render(
+      <Dialog open={false} onClose={()=>{}}>
+          Dialog
+          <DialogTitle>Title</DialogTitle>
+          <DialogContent>
+            <DialogContentText>Content Text</DialogContentText>
+            <div>Content</div>
+          </DialogContent>
+          <DialogActions>
+            <button>Button 1</button>
+            <button>Button 2</button>
+          </DialogActions>
+      </Dialog>
+      );
+    
+    expect(dialog.queryByTestId('dialog-element') as HTMLElement).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dialog-title-element') as HTMLElement).not.toBeInTheDocument();
+    expect(dialog.queryByTestId('dialog-body-element') as HTMLElement).not.toBeInTheDocument();
+    expect(dialog.queryByTestId('dialog-actions-element') as HTMLElement).not.toBeInTheDocument();
+    expect(dialog.queryByTestId('dialog-content-element') as HTMLElement).not.toBeInTheDocument();
+    expect(dialog.queryByTestId('dialog-contenttext-element') as HTMLElement).not.toBeInTheDocument();
+    expect(dialog.queryByText('Dialog') as HTMLElement).not.toBeInTheDocument();
+    expect(screen.queryByText('Title') as HTMLElement).not.toBeInTheDocument();
+    expect(screen.queryByText('Content Text') as HTMLElement).not.toBeInTheDocument();
+    expect(screen.queryByText('Content') as HTMLElement).not.toBeInTheDocument();
+    expect(screen.queryByText('Button 1') as HTMLElement).not.toBeInTheDocument();
+    expect(screen.queryByText('Button 2') as HTMLElement).not.toBeInTheDocument();
+  });
+  it('should render Dialog Component and sub-components when open is true', ()=>{
+    const dialog = render(
+      <Dialog open={true} onClose={()=>{}}>
+          Dialog
+          <DialogTitle>Title</DialogTitle>
+          <DialogContent>
+            <DialogContentText>Content Text</DialogContentText>
+            <div>Content</div>
+          </DialogContent>
+          <DialogActions>
+            <button>Button 1</button>
+            <button>Button 2</button>
+          </DialogActions>
+      </Dialog>
+      );
+    
+    expect(dialog.queryByTestId('dialog-element') as HTMLElement).toBeInTheDocument();
+    expect(screen.queryByTestId('dialog-title-element') as HTMLElement).toBeInTheDocument();
+    expect(dialog.queryByTestId('dialog-body-element') as HTMLElement).toBeInTheDocument();
+    expect(dialog.queryByTestId('dialog-actions-element') as HTMLElement).toBeInTheDocument();
+    expect(dialog.queryByTestId('dialog-content-element') as HTMLElement).toBeInTheDocument();
+    expect(dialog.queryByTestId('dialog-contenttext-element') as HTMLElement).toBeInTheDocument();
+    expect(dialog.queryByText('Dialog') as HTMLElement).toBeInTheDocument();
+    expect(screen.queryByText('Title') as HTMLElement).toBeInTheDocument();
+    expect(screen.queryByText('Content Text') as HTMLElement).toBeInTheDocument();
+    expect(screen.queryByText('Content') as HTMLElement).toBeInTheDocument();
+    expect(screen.queryByText('Button 1') as HTMLElement).toBeInTheDocument();
+    expect(screen.queryByText('Button 2') as HTMLElement).toBeInTheDocument();
+  });
+  it('should render Dialog Title Component as per props', ()=>{
+    const dialogTitleComponent = render(
+      <DialogTitle className="class1 class2">Dialog Title</DialogTitle>
+      );
+    const dialogTitleElement = dialogTitleComponent.queryByText('Dialog Title') as HTMLElement;
+    expect(dialogTitleElement).toBeInTheDocument();
+    expect(dialogTitleElement).toHaveClass('dialog__title');
+    expect(screen.queryByText('Dialog Title') as HTMLElement).toBeInTheDocument();
+    expect(screen.queryByText('Dialog Title') as HTMLElement).toHaveClass('dialog__title');
+    /* checking if additional classes are present in rendered component */
+    expect(screen.queryByText('Dialog Title') as HTMLElement).toHaveClass('class1');
+    expect(screen.queryByText('Dialog Title') as HTMLElement).toHaveClass('class2');
+    expect(screen.queryByText('Dialog Title 1') as HTMLElement).not.toBeInTheDocument();
+  });
+  
+  it('should render DialogContent component as per props', ()=>{
+    const component = render(
+      <DialogContent className="class1 class2">
+      Dialog Content
+      </DialogContent>
+      );
+    const element = component.queryByText('Dialog Content') as HTMLElement;
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveClass('dialog__content');
+    expect(screen.queryByText('Dialog Content') as HTMLElement).toBeInTheDocument();
+    expect(screen.queryByText('Dialog Content') as HTMLElement).toHaveClass('dialog__content');
+    /* checking if additional classes are present in rendered component */
+    expect(screen.queryByText('Dialog Content') as HTMLElement).toHaveClass('class1');
+    expect(screen.queryByText('Dialog Content') as HTMLElement).toHaveClass('class2');
+    expect(screen.queryByText('Dialog Content 1') as HTMLElement).not.toBeInTheDocument(); 
+  });
+  it('should render DialogContentText component as per props', ()=>{
+    const component = render(
+      <DialogContentText className='class1 class2'>Dialog Content Text
+      </DialogContentText>
+      );
+    const element = component.queryByText('Dialog Content Text') as HTMLElement;
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveClass('dialog__content-text');
+    expect(screen.queryByText('Dialog Content Text') as HTMLElement).toBeInTheDocument();
+    expect(screen.queryByText('Dialog Content Text') as HTMLElement).toHaveClass('dialog__content-text');
+    /* checking if additional classes are present in rendered component */
+    expect(screen.queryByText('Dialog Content Text') as HTMLElement).toHaveClass('class1');
+    expect(screen.queryByText('Dialog Content Text') as HTMLElement).toHaveClass('class2');
+    expect(screen.queryByText('Dialog Content Text 1') as HTMLElement).not.toBeInTheDocument(); 
+  });
+  it('should render DialogActions component', ()=>{
+    const component = render(
+      <DialogActions className='class1 class2'>
+        Dialog Actions
+      </DialogActions>
+      );
+    const element = component.queryByText('Dialog Actions') as HTMLElement;
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveClass('dialog__actions');
+    expect(screen.queryByText('Dialog Actions') as HTMLElement).toBeInTheDocument();
+    expect(screen.queryByText('Dialog Actions') as HTMLElement).toHaveClass('dialog__actions');
+    /* checking if additional classes are present in rendered component */
+    expect(screen.queryByText('Dialog Actions') as HTMLElement).toHaveClass('class1');
+    expect(screen.queryByText('Dialog Actions') as HTMLElement).toHaveClass('class2');
+    expect(screen.queryByText('Dialog Actions 1') as HTMLElement).not.toBeInTheDocument(); 
+  });  
+  
+  it('should have a dimed backdrop by default, users can close the dialog by clicking on the backdrop', () => {
+    expect(1+2).toEqual(3);
+  });
 });
 describe('Users of Dialog Component', () => {
-  it('should not be able to scroll the page when the dialog is open', () => {});
-  it('should be able to listen to the close of the dialog by providing the onClose callback function.', () => {});
-  it('should be able to control the open/close of the dialog from props.', () => {});
+  it('should not be able to scroll the page when the dialog is open', () => {
+    expect(1+2).toEqual(3);
+  });
+  it('should be able to listen to the close of the dialog by providing the onClose callback function.', () => {
+    const onCloseHandler = jest.fn((event, reason)=>{});
+    const component = render(
+      <Dialog open={true} onClose={onCloseHandler}>
+        <div>Dialog</div>
+      </Dialog>);
+    
+    /* checking if onClose is triggered on backdrop click*/
+    const backDrop = component.getByTestId('dialog-element');
+    expect(onCloseHandler).toHaveBeenCalledTimes(0);
+    fireEvent.click(backDrop);
+    expect(onCloseHandler).toHaveBeenCalledTimes(1);
+    
+    /* checkign if onClose is not triggered when clicked on dialog body (not backdrop) */
+    const dialogBody = component.getByTestId('dialog-body-element');
+    fireEvent.click(dialogBody);
+    expect(onCloseHandler).toHaveBeenCalledTimes(1);
+
+  });
+  it('should be able to listen to close of dialog by escape key down event by default', ()=>{
+    const onCloseHandler = jest.fn((event, reason)=>{});
+    const component = render(
+      <Dialog open={true} onClose={onCloseHandler}>
+        <div>Dialog</div>
+      </Dialog>);
+    expect(onCloseHandler).toHaveBeenCalledTimes(0);
+    fireEvent.keyDown(document, {
+      key: "Escape",
+      code: "Escape",
+      keyCode: 27,
+      charCode: 27
+    });
+    expect(onCloseHandler).toHaveBeenCalledTimes(1);
+  })
+  it('should be able to control the open/close of the dialog from props.', () => {
+   expect(1+2).toEqual(3);
+  });
 });

--- a/src/components/Dialogue/Dialog.test.tsx
+++ b/src/components/Dialogue/Dialog.test.tsx
@@ -145,12 +145,59 @@ describe('Dialog Component and sub-components', () => {
   });  
   
   it('should have a dimed backdrop by default, users can close the dialog by clicking on the backdrop', () => {
-    expect(1+2).toEqual(3);
+    const dialog = render(
+      <Dialog open={true} onClose={()=>{}}>
+          Dialog
+          <DialogTitle>Title</DialogTitle>
+          <DialogContent>
+            <DialogContentText>Content Text</DialogContentText>
+            <div>Content</div>
+          </DialogContent>
+          <DialogActions>
+            <button>Button 1</button>
+            <button>Button 2</button>
+          </DialogActions>
+      </Dialog>
+      );
+    expect(dialog.getByTestId('dialog-element').style.opacity).toBe("0.5");
   });
 });
 describe('Users of Dialog Component', () => {
   it('should not be able to scroll the page when the dialog is open', () => {
-    expect(1+2).toEqual(3);
+    const dialog = render(
+      <Dialog open={true} onClose={()=>{}}>
+          Dialog
+          <DialogTitle>Title</DialogTitle>
+          <DialogContent>
+            <DialogContentText>Content Text</DialogContentText>
+            <div>Content</div>
+          </DialogContent>
+          <DialogActions>
+            <button>Button 1</button>
+            <button>Button 2</button>
+          </DialogActions>
+      </Dialog>
+      );
+    expect(dialog.queryByTestId('dialog-element') as HTMLElement).toBeInTheDocument();
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+  it('should be able to scroll the page when the dialog is closed', () => {
+    const dialog = render(
+      <Dialog open={false} onClose={()=>{}}>
+          Dialog
+          <DialogTitle>Title</DialogTitle>
+          <DialogContent>
+            <DialogContentText>Content Text</DialogContentText>
+            <div>Content</div>
+          </DialogContent>
+          <DialogActions>
+            <button>Button 1</button>
+            <button>Button 2</button>
+          </DialogActions>
+      </Dialog>
+      );
+    expect(dialog.queryByTestId('dialog-element') as HTMLElement).not.toBeInTheDocument();
+    expect(document.body.style.overflow).not.toBe('hidden');
   });
   it('should be able to listen to the close of the dialog by providing the onClose callback function.', () => {
     const onCloseHandler = jest.fn((event, reason)=>{});
@@ -186,7 +233,5 @@ describe('Users of Dialog Component', () => {
     });
     expect(onCloseHandler).toHaveBeenCalledTimes(1);
   })
-  it('should be able to control the open/close of the dialog from props.', () => {
-   expect(1+2).toEqual(3);
-  });
+  
 });

--- a/src/components/Dialogue/Dialog.tsx
+++ b/src/components/Dialogue/Dialog.tsx
@@ -1,45 +1,49 @@
-import React, { FC, MouseEvent, useState, useEffect } from 'react';
+import React, { FC, MouseEvent, useEffect, HTMLAttributes } from 'react';
 import { classNames } from '../../utils/classNames';
 
-export type DialogCloseReason = 
-  | 'backdropClick' 
-  | 'escapeKeyDown';
+export type DialogCloseReason = 'backdropClick' | 'escapeKeyDown';
 
-export type MaxWidthSizeType = 
-'xs'
-| 'sm'
-| 'md'
-| 'lg'
-| 'xl'
-| false
-| string
+export type MaxWidthSizeType =
+  | 'xs'
+  | 'sm'
+  | 'md'
+  | 'lg'
+  | 'xl'
+  | false
+  | string;
 
-export type ScrollType = 
-| 'body'
-| 'paper'
+const MaxWidthSizeTypeClass = {
+  xs: '--dialog-body-max-width-xs',
+  sm: '--dialog-body-max-width-sm',
+  md: '--dialog-body-max-width-md',
+  lg: '--dialog-body-max-width-lg',
+  xl: '--dialog-body-max-width-xl',
+};
+
+export type ScrollType = 'body' | 'paper';
 
 export interface IDialogProps {
   /** set customized style */
   className?: string;
   /** set whether dialog is open / visible */
-  open:boolean;
+  open: boolean;
   /** set callback function on closing dialog */
-  onClose:(event:object, reason: DialogCloseReason)=>void;
+  onClose: (event: object, reason: DialogCloseReason) => void;
   /** set aria-describedby to include id of element used to describe component*/
-  ariaDescribedBy?:string;
+  ariaDescribedBy?: string;
   /** set aria-labelledby to include id of element used to label component*/
-  ariaLabelledBy?:string;
+  ariaLabelledBy?: string;
   /** set whether escape key triggers onClose handler */
-  disableEscapeKeyDown?:boolean
+  disableEscapeKeyDown?: boolean;
   /** set maxWidth */
-  maxWidth?:MaxWidthSizeType;
+  maxWidth?: MaxWidthSizeType;
   /** set whether the dialog is fullScreen */
-  fullScreen?:boolean
+  fullScreen?: boolean;
   /** set scroll */
-  scroll?:ScrollType
+  scroll?: ScrollType;
 }
 
-export type PatDialogProps = IDialogProps
+export type PatDialogProps = IDialogProps & HTMLAttributes<HTMLDivElement>;
 
 /**
  * Dialogs inform users about a task and can contain critical information
@@ -49,81 +53,102 @@ export type PatDialogProps = IDialogProps
  * ```
  */
 export const Dialog: FC<PatDialogProps> = (props) => {
-  
-  const { open, onClose, disableEscapeKeyDown, maxWidth, children, className, ...rest } = props;
-  const handleBackdropClick = (e)=>{
-    onClose(e, 'backdropClick')
-  }
-  const handleEscapeKeyDown = (e) =>{
-    if(e.key==='Escape') {
+  const {
+    open,
+    onClose,
+    disableEscapeKeyDown,
+    maxWidth,
+    children,
+    className,
+    ...rest
+  } = props;
+  const handleBackdropClick = (e: MouseEvent) => {
+    onClose(e, 'backdropClick');
+  };
+  const handleEscapeKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
       onClose(e, 'escapeKeyDown');
     }
-  }
-  const handleBackdropScrollingBasedOnDialogState = ()=>{
-    if(open === true) document.body.style.overflow='hidden';
-    else document.body.style.overflow='unset'; 
-  }
-  
+  };
+  const handleBackdropScrollingBasedOnDialogState = () => {
+    if (open === true) document.body.style.overflow = 'hidden';
+    else document.body.style.overflow = 'unset';
+  };
+
   /** add escape key event listener at the start based on props */
-  useEffect(()=>{
-    if(disableEscapeKeyDown){
-      document.addEventListener('keydown', (e)=>{
+  useEffect(() => {
+    if (disableEscapeKeyDown) {
+      document.addEventListener('keydown', (e: KeyboardEvent) => {
         handleEscapeKeyDown(e);
-      })
+      });
     }
-  }, [])
+  }, []);
 
   /** enable / disable scrolling of backdrop based on whether dialog is open */
-  useEffect(()=>{
+  useEffect(() => {
     handleBackdropScrollingBasedOnDialogState();
-  }, [open])
-  
+  }, [open]);
+
   let styleClasses;
   if (className) styleClasses = 'dialog ' + className;
-  else styleClasses  = 'dialog';
+  else styleClasses = 'dialog';
   let dialogBodyClasses = 'dialog__body';
-  switch(maxWidth) {
-    case 'xs':{
-      dialogBodyClasses += ' ' + 'dialog-body-width-xs';
-          break;
-    }
-    case 'sm':{
-      dialogBodyClasses += ' ' + 'dialog-body-width-sm';
-          break;
-    }
-    case 'md':{
-      dialogBodyClasses += ' ' + 'dialog-body-width-md';
-          break;
-    }
-    case 'lg':{
-      dialogBodyClasses += ' ' + 'dialog-body-width-lg';
-          break;
-    }
-    case 'xl':{
-      dialogBodyClasses += ' ' + 'dialog-body-width-xl';
-          break;
-    }
-    default:{
-          dialogBodyClasses += ' ' + 'dialog-body-width-sm';
-          break;
+  if (maxWidth !== false) {
+    switch (maxWidth) {
+      case 'xs': {
+        dialogBodyClasses += ' ' + MaxWidthSizeTypeClass.xs;
+        break;
       }
+      case 'sm': {
+        dialogBodyClasses += ' ' + MaxWidthSizeTypeClass.sm;
+        break;
+      }
+      case 'md': {
+        dialogBodyClasses += ' ' + MaxWidthSizeTypeClass.md;
+        break;
+      }
+      case 'lg': {
+        dialogBodyClasses += ' ' + MaxWidthSizeTypeClass.lg;
+        break;
+      }
+      case 'xl': {
+        dialogBodyClasses += ' ' + MaxWidthSizeTypeClass.xl;
+        break;
+      }
+      default: {
+        dialogBodyClasses += ` ${MaxWidthSizeTypeClass.sm}`;
+        break;
+      }
+    }
   }
   let dialog;
   dialog = open ? (
-    <div onClick={handleBackdropClick} className={classNames(styleClasses)} data-testid='dialog-element'>
-      <div onClick={(e)=>{e.stopPropagation()}} className={classNames(dialogBodyClasses)} data-testid='dialog-body-element'>
+    <div
+      onClick={handleBackdropClick}
+      className={classNames(styleClasses)}
+      data-testid="dialog-element"
+    >
+      <div
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+        className={classNames(dialogBodyClasses)}
+        data-testid="dialog-body-element"
+      >
         {props.children}
       </div>
-    </div>) : <></>;
+    </div>
+  ) : (
+    <></>
+  );
   return dialog;
 };
 
 Dialog.defaultProps = {
-  disableEscapeKeyDown:true,
-  maxWidth:'sm',
-  fullScreen:false,
-  fullWidth:false,
-  scroll:'paper'
+  disableEscapeKeyDown: true,
+  maxWidth: 'sm',
+  fullScreen: false,
+  scroll: 'paper',
 };
 
 export default Dialog;

--- a/src/components/Dialogue/Dialog.tsx
+++ b/src/components/Dialogue/Dialog.tsx
@@ -3,7 +3,20 @@ import { classNames } from '../../utils/classNames';
 
 export type DialogCloseReason = 
   | 'backdropClick' 
-  | 'escapeKeyDown'
+  | 'escapeKeyDown';
+
+export type MaxWidthSizeType = 
+'xs'
+| 'sm'
+| 'md'
+| 'lg'
+| 'xl'
+| false
+| string
+
+export type ScrollType = 
+| 'body'
+| 'paper'
 
 export interface IDialogProps {
   /** set customized style */
@@ -12,33 +25,66 @@ export interface IDialogProps {
   open:boolean;
   /** set callback function on closing dialog */
   onClose:(event:object, reason: DialogCloseReason)=>void;
+  /** set aria-describedby to include id of element used to describe component*/
+  ariaDescribedBy?:string;
+  /** set aria-labelledby to include id of element used to label component*/
+  ariaLabelledBy?:string;
+  /** set whether escape key triggers onClose handler */
+  disableEscapeKeyDown?:boolean
+  /** set whether the dialog is fullScreen */
+  fullScreen?:boolean
+  /** set maxWidth of the dialog */
+  maxWidth?:MaxWidthSizeType
+  /** set scroll */
+  scroll?:ScrollType
 }
 
 export type PatDialogProps = IDialogProps
 
 /**
- * A Button indicates a possible user action.
+ * Dialogs inform users about a task and can contain critical information
  *
  * ```js
- * import {Button} from 'pat-ui'
+ * import {Dialog} from 'pat-ui'
  * ```
  */
 export const Dialog: FC<PatDialogProps> = (props) => {
   
-  const { open, onClose, children, className, ...rest } = props;
+  const { open, onClose, disableEscapeKeyDown, children, className, ...rest } = props;
   const handleBackdropClick = (e)=>{
     onClose(e, 'backdropClick')
   }
   const handleEscapeKeyDown = (e) =>{
-    if(e.key==='Escape') onClose(e, 'escapeKeyDown');
+    if(e.key==='Escape') {
+      onClose(e, 'escapeKeyDown');
+    }
   }
+  const handleBackdropScrollingBasedOnDialogState = ()=>{
+    if(open === true) document.body.style.overflow='hidden';
+    else document.body.style.overflow='unset'; 
+  }
+  
+  /** add escape key event listener at the start based on props */
+  useEffect(()=>{
+    if(disableEscapeKeyDown){
+      document.addEventListener('keydown', (e)=>{
+        handleEscapeKeyDown(e);
+      })
+    }
+  }, [])
+
+  /** enable / disable scrolling of backdrop based on whether dialog is open */
+  useEffect(()=>{
+    handleBackdropScrollingBasedOnDialogState();
+  }, [open])
+  
   let styleClasses = 'dialog';
   if (className) styleClasses += ' ' + className;
 
   let dialog;
   dialog = open ? (
-    <div onClick={handleBackdropClick} tab-index="0" onKeyDown={handleEscapeKeyDown} className={styleClasses}>
-      <div onClick={(e)=>{e.stopPropagation()}} className='dialog__body'>
+    <div onClick={handleBackdropClick} className={styleClasses} data-testid='dialog-element'>
+      <div onClick={(e)=>{e.stopPropagation()}} className='dialog__body' data-testid='dialog-body-element'>
         {props.children}
       </div>
     </div>) : <></>;
@@ -46,7 +92,11 @@ export const Dialog: FC<PatDialogProps> = (props) => {
 };
 
 Dialog.defaultProps = {
-  open:true
+  disableEscapeKeyDown:true,
+  maxWidth:'sm',
+  fullScreen:false,
+  fullWidth:false,
+  scroll:'paper'
 };
 
 export default Dialog;

--- a/src/components/Dialogue/Dialog.tsx
+++ b/src/components/Dialogue/Dialog.tsx
@@ -63,7 +63,9 @@ export const Dialog: FC<PatDialogProps> = (props) => {
     ...rest
   } = props;
   const handleBackdropClick = (e: MouseEvent) => {
-    onClose(e, 'backdropClick');
+    if ((e.target as HTMLElement).classList.contains('dialog')) {
+      onClose(e, 'backdropClick');
+    }
   };
   const handleEscapeKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Escape') {
@@ -89,38 +91,17 @@ export const Dialog: FC<PatDialogProps> = (props) => {
     handleBackdropScrollingBasedOnDialogState();
   }, [open]);
 
-  let styleClasses;
-  if (className) styleClasses = 'dialog ' + className;
-  else styleClasses = 'dialog';
-  let dialogBodyClasses = 'dialog__body';
-  if (maxWidth !== false) {
-    switch (maxWidth) {
-      case 'xs': {
-        dialogBodyClasses += ' ' + MaxWidthSizeTypeClass.xs;
-        break;
-      }
-      case 'sm': {
-        dialogBodyClasses += ' ' + MaxWidthSizeTypeClass.sm;
-        break;
-      }
-      case 'md': {
-        dialogBodyClasses += ' ' + MaxWidthSizeTypeClass.md;
-        break;
-      }
-      case 'lg': {
-        dialogBodyClasses += ' ' + MaxWidthSizeTypeClass.lg;
-        break;
-      }
-      case 'xl': {
-        dialogBodyClasses += ' ' + MaxWidthSizeTypeClass.xl;
-        break;
-      }
-      default: {
-        dialogBodyClasses += ` ${MaxWidthSizeTypeClass.sm}`;
-        break;
-      }
-    }
-  }
+  let styleClasses = { dialog: true };
+
+  let dialogBodyClasses = {
+    dialog__body: true,
+    [MaxWidthSizeTypeClass.xs]: maxWidth === 'xs',
+    [MaxWidthSizeTypeClass.sm]: maxWidth === 'sm',
+    [MaxWidthSizeTypeClass.md]: maxWidth === 'md',
+    [MaxWidthSizeTypeClass.lg]: maxWidth === 'lg',
+    [MaxWidthSizeTypeClass.xl]: maxWidth === 'xl',
+  };
+
   let dialog;
   dialog = open ? (
     <div
@@ -129,18 +110,14 @@ export const Dialog: FC<PatDialogProps> = (props) => {
       data-testid="dialog-element"
     >
       <div
-        onClick={(e) => {
-          e.stopPropagation();
-        }}
         className={classNames(dialogBodyClasses)}
         data-testid="dialog-body-element"
+        {...(rest as PatDialogProps)}
       >
         {props.children}
       </div>
     </div>
-  ) : (
-    <></>
-  );
+  ) : null;
   return dialog;
 };
 

--- a/src/components/Dialogue/Dialog.tsx
+++ b/src/components/Dialogue/Dialog.tsx
@@ -31,10 +31,10 @@ export interface IDialogProps {
   ariaLabelledBy?:string;
   /** set whether escape key triggers onClose handler */
   disableEscapeKeyDown?:boolean
+  /** set maxWidth */
+  maxWidth?:MaxWidthSizeType;
   /** set whether the dialog is fullScreen */
   fullScreen?:boolean
-  /** set maxWidth of the dialog */
-  maxWidth?:MaxWidthSizeType
   /** set scroll */
   scroll?:ScrollType
 }
@@ -50,7 +50,7 @@ export type PatDialogProps = IDialogProps
  */
 export const Dialog: FC<PatDialogProps> = (props) => {
   
-  const { open, onClose, disableEscapeKeyDown, children, className, ...rest } = props;
+  const { open, onClose, disableEscapeKeyDown, maxWidth, children, className, ...rest } = props;
   const handleBackdropClick = (e)=>{
     onClose(e, 'backdropClick')
   }
@@ -78,13 +78,40 @@ export const Dialog: FC<PatDialogProps> = (props) => {
     handleBackdropScrollingBasedOnDialogState();
   }, [open])
   
-  let styleClasses = 'dialog';
-  if (className) styleClasses += ' ' + className;
-
+  let styleClasses;
+  if (className) styleClasses = 'dialog ' + className;
+  else styleClasses  = 'dialog';
+  let dialogBodyClasses = 'dialog__body';
+  switch(maxWidth) {
+    case 'xs':{
+      dialogBodyClasses += ' ' + 'dialog-body-width-xs';
+          break;
+    }
+    case 'sm':{
+      dialogBodyClasses += ' ' + 'dialog-body-width-sm';
+          break;
+    }
+    case 'md':{
+      dialogBodyClasses += ' ' + 'dialog-body-width-md';
+          break;
+    }
+    case 'lg':{
+      dialogBodyClasses += ' ' + 'dialog-body-width-lg';
+          break;
+    }
+    case 'xl':{
+      dialogBodyClasses += ' ' + 'dialog-body-width-xl';
+          break;
+    }
+    default:{
+          dialogBodyClasses += ' ' + 'dialog-body-width-sm';
+          break;
+      }
+  }
   let dialog;
   dialog = open ? (
-    <div onClick={handleBackdropClick} className={styleClasses} data-testid='dialog-element'>
-      <div onClick={(e)=>{e.stopPropagation()}} className='dialog__body' data-testid='dialog-body-element'>
+    <div onClick={handleBackdropClick} className={classNames(styleClasses)} data-testid='dialog-element'>
+      <div onClick={(e)=>{e.stopPropagation()}} className={classNames(dialogBodyClasses)} data-testid='dialog-body-element'>
         {props.children}
       </div>
     </div>) : <></>;

--- a/src/components/Dialogue/Dialog.tsx
+++ b/src/components/Dialogue/Dialog.tsx
@@ -1,32 +1,20 @@
-import React, { FC, MouseEvent } from 'react';
+import React, { FC, MouseEvent, useState, useEffect } from 'react';
 import { classNames } from '../../utils/classNames';
 
-// export enum ButtonSize {
-//   Large = 'lg',
-//   Small = 'sm',
-// }
-export type ButtonSize = 'lg' | 'sm';
-export type ButtonType =
-  | 'primary'
-  | 'secondary'
-  | 'danger'
-  | 'default'
-  | 'link';
-// export enum ButtonType {
-//   Primary = 'primary',
-//   Secondary = 'secondary',
-//   Danger = 'danger',
-//   Default = 'default',
-//   Link = 'link',
-// }
+export type DialogCloseReason = 
+  | 'backdropClick' 
+  | 'escapeKeyDown'
+
 export interface IDialogProps {
   /** set customized style */
   className?: string;
+  /** set whether dialog is open / visible */
+  open:boolean;
+  /** set callback function on closing dialog */
+  onClose:(event:object, reason: DialogCloseReason)=>void;
 }
 
-type NativeButtonProps = IDialogProps;
-type NativeAchorButtonProps = IDialogProps;
-export type PatDialogProps = NativeButtonProps | NativeAchorButtonProps;
+export type PatDialogProps = IDialogProps
 
 /**
  * A Button indicates a possible user action.
@@ -36,20 +24,29 @@ export type PatDialogProps = NativeButtonProps | NativeAchorButtonProps;
  * ```
  */
 export const Dialog: FC<PatDialogProps> = (props) => {
-  const { children, className, ...rest } = props;
+  
+  const { open, onClose, children, className, ...rest } = props;
+  const handleBackdropClick = (e)=>{
+    onClose(e, 'backdropClick')
+  }
+  const handleEscapeKeyDown = (e) =>{
+    if(e.key==='Escape') onClose(e, 'escapeKeyDown');
+  }
   let styleClasses = 'dialog';
   if (className) styleClasses += ' ' + className;
 
   let dialog;
-  dialog = (
-    <div className={styleClasses}>
-      <div className='dialog__content'>
-      {props.children}
+  dialog = open ? (
+    <div onClick={handleBackdropClick} tab-index="0" onKeyDown={handleEscapeKeyDown} className={styleClasses}>
+      <div onClick={(e)=>{e.stopPropagation()}} className='dialog__body'>
+        {props.children}
       </div>
-    </div>);
+    </div>) : <></>;
   return dialog;
 };
 
-Dialog.defaultProps = {};
+Dialog.defaultProps = {
+  open:true
+};
 
 export default Dialog;

--- a/src/components/Dialogue/Dialog.tsx
+++ b/src/components/Dialogue/Dialog.tsx
@@ -1,0 +1,50 @@
+import React, { FC, MouseEvent } from 'react';
+import { classNames } from '../../utils/classNames';
+
+// export enum ButtonSize {
+//   Large = 'lg',
+//   Small = 'sm',
+// }
+export type ButtonSize = 'lg' | 'sm';
+export type ButtonType =
+  | 'primary'
+  | 'secondary'
+  | 'danger'
+  | 'default'
+  | 'link';
+// export enum ButtonType {
+//   Primary = 'primary',
+//   Secondary = 'secondary',
+//   Danger = 'danger',
+//   Default = 'default',
+//   Link = 'link',
+// }
+export interface IDialogProps {
+  /** set customized style */
+  className?: string;
+}
+
+type NativeButtonProps = IDialogProps;
+type NativeAchorButtonProps = IDialogProps;
+export type PatDialogProps = NativeButtonProps | NativeAchorButtonProps;
+
+/**
+ * A Button indicates a possible user action.
+ *
+ * ```js
+ * import {Button} from 'pat-ui'
+ * ```
+ */
+export const Dialog: FC<PatDialogProps> = (props) => {
+  const { children, className, ...rest } = props;
+  let styleClasses = 'dialog';
+  if (className) styleClasses += ' ' + className;
+
+  let dialog;
+  dialog = <div className={styleClasses}>{props.children}</div>;
+  return dialog;
+};
+
+Dialog.defaultProps = {};
+
+export default Dialog;

--- a/src/components/Dialogue/Dialog.tsx
+++ b/src/components/Dialogue/Dialog.tsx
@@ -41,8 +41,12 @@ export const Dialog: FC<PatDialogProps> = (props) => {
   if (className) styleClasses += ' ' + className;
 
   let dialog;
-  let dialogContent = <div className='dialog__content'>{props.children}</div>
-  dialog = <div className={styleClasses}>dialogContent</div>;
+  dialog = (
+    <div className={styleClasses}>
+      <div className='dialog__content'>
+      {props.children}
+      </div>
+    </div>);
   return dialog;
 };
 

--- a/src/components/Dialogue/Dialog.tsx
+++ b/src/components/Dialogue/Dialog.tsx
@@ -41,7 +41,8 @@ export const Dialog: FC<PatDialogProps> = (props) => {
   if (className) styleClasses += ' ' + className;
 
   let dialog;
-  dialog = <div className={styleClasses}>{props.children}</div>;
+  let dialogContent = <div className='dialog__content'>{props.children}</div>
+  dialog = <div className={styleClasses}>dialogContent</div>;
   return dialog;
 };
 

--- a/src/components/Dialogue/DialogActions.tsx
+++ b/src/components/Dialogue/DialogActions.tsx
@@ -8,7 +8,7 @@ export interface IDialogActionsProps {
 export type PatDialogActionsProps = IDialogActionsProps &
   HTMLAttributes<HTMLDivElement>;
 
-const DialogActions: FC<PatDialogActionsProps> = (props) => {
+export const DialogActions: FC<PatDialogActionsProps> = (props) => {
   const { disableSpacing, children, className } = props;
 
   let dialogActions = (

--- a/src/components/Dialogue/DialogActions.tsx
+++ b/src/components/Dialogue/DialogActions.tsx
@@ -10,7 +10,7 @@ export type PatDialogActionsProps = IDialogActionsProps
 const DialogActions:FC<PatDialogActionsProps> = (props)=>{
 const { disableSpacing, children, className } = props;
 
-let dialogActions = <div className={`dialog__actions `+className}>{children}</div>
+let dialogActions = <div className={`dialog__actions `+className} data-testid='dialog-actions-element'>{children}</div>
 if(disableSpacing) {
 	dialogActions.style.gap = 0;
 }

--- a/src/components/Dialogue/DialogActions.tsx
+++ b/src/components/Dialogue/DialogActions.tsx
@@ -2,10 +2,21 @@ import React, { FC } from 'react';
 export interface IDialogActionsProps{
 	/** set style classes*/
 	className?:string;
+	/** set whether to space child components */
+	disableSpacing?:boolean;
 }
 export type PatDialogActionsProps = IDialogActionsProps
+
 const DialogActions:FC<PatDialogActionsProps> = (props)=>{
-const { children, className } = props;
-return <div className={className}>{children}</div>
+const { disableSpacing, children, className } = props;
+
+let dialogActions = <div className={`dialog__actions `+className}>{children}</div>
+if(disableSpacing) {
+	dialogActions.style.gap = 0;
+}
+return dialogActions;
+}
+DialogActions.defaultProps = {
+	disableSpacing:false
 }
 export default DialogActions;

--- a/src/components/Dialogue/DialogActions.tsx
+++ b/src/components/Dialogue/DialogActions.tsx
@@ -1,0 +1,11 @@
+import React, { FC } from 'react';
+export interface IDialogActionsProps{
+	/** set style classes*/
+	className?:string;
+}
+export type PatDialogActionsProps = IDialogActionsProps
+const DialogActions:FC<PatDialogActionsProps> = (props)=>{
+const { children, className } = props;
+return <div className={className}>{children}</div>
+}
+export default DialogActions;

--- a/src/components/Dialogue/DialogActions.tsx
+++ b/src/components/Dialogue/DialogActions.tsx
@@ -1,22 +1,30 @@
-import React, { FC } from 'react';
-export interface IDialogActionsProps{
-	/** set style classes*/
-	className?:string;
-	/** set whether to space child components */
-	disableSpacing?:boolean;
+import React, { FC, HTMLAttributes } from 'react';
+export interface IDialogActionsProps {
+  /** set style classes*/
+  className?: string;
+  /** set whether to space child components */
+  disableSpacing?: boolean;
 }
-export type PatDialogActionsProps = IDialogActionsProps
+export type PatDialogActionsProps = IDialogActionsProps &
+  HTMLAttributes<HTMLDivElement>;
 
-const DialogActions:FC<PatDialogActionsProps> = (props)=>{
-const { disableSpacing, children, className } = props;
+const DialogActions: FC<PatDialogActionsProps> = (props) => {
+  const { disableSpacing, children, className } = props;
 
-let dialogActions = <div className={`dialog__actions `+className} data-testid='dialog-actions-element'>{children}</div>
-if(disableSpacing) {
-	dialogActions.style.gap = 0;
-}
-return dialogActions;
-}
+  let dialogActions = (
+    <div
+      className={`dialog__actions ${className} ${
+        !disableSpacing && '--dialog__actions-gap'
+      }`}
+      data-testid="dialog-actions-element"
+    >
+      {children}
+    </div>
+  );
+
+  return dialogActions;
+};
 DialogActions.defaultProps = {
-	disableSpacing:false
-}
+  disableSpacing: false,
+};
 export default DialogActions;

--- a/src/components/Dialogue/DialogContent.tsx
+++ b/src/components/Dialogue/DialogContent.tsx
@@ -8,9 +8,11 @@ export interface IDialogContentProps{
 export type PatDialogContentProps = IDialogContentProps
 const DialogContent:FC<PatDialogContentProps> = (props)=>{
 let classes = 'dialog__content';
-const { children, className } = props;
+const { dividers, children, className } = props;
 if(className) classes += ' ' + className;
-	return <div className={classes}>{children}</div>
+	return dividers ? 
+	(<div className={classes} data-testid='dialog-content-element'><hr/>{children}<hr/></div>) :
+	(<div className={classes} data-testid='dialog-content-element'>{children}</div>)
 }
 
 DialogContent.defaultProps = {

--- a/src/components/Dialogue/DialogContent.tsx
+++ b/src/components/Dialogue/DialogContent.tsx
@@ -1,21 +1,35 @@
-import React, { FC } from 'react';
-export interface IDialogContentProps{
-	/** set style classes*/
-	className?:string;
-	/** set dividers option */
-	dividers?:boolean;
-}
-export type PatDialogContentProps = IDialogContentProps
-const DialogContent:FC<PatDialogContentProps> = (props)=>{
-let classes = 'dialog__content';
-const { dividers, children, className } = props;
-if(className) classes += ' ' + className;
-	return dividers ? 
-	(<div className={classes} data-testid='dialog-content-element'><hr />{children}<hr /></div>) :
-	(<div className={classes} data-testid='dialog-content-element'>{children}</div>)
+import React, { FC, HTMLAttributes } from 'react';
+export interface IDialogContentProps {
+  /** set style classes*/
+  className?: string;
+  /** set dividers option */
+  dividers?: boolean;
 }
 
+const divider: FC = () => {
+  return <hr />;
+};
+export type PatDialogContentProps = IDialogContentProps &
+  HTMLAttributes<HTMLDivElement>;
+const DialogContent: FC<PatDialogContentProps> = (props) => {
+  let classes = 'dialog__content';
+  const { dividers, children, className } = props;
+
+  if (className) classes += ' ' + className;
+  return dividers ? (
+    <div className={classes} data-testid="dialog-content-element">
+      <hr className="dialog-content-divider" />
+      {children}
+      <hr className="dialog-content-divider" />
+    </div>
+  ) : (
+    <div className={classes} data-testid="dialog-content-element">
+      {children}
+    </div>
+  );
+};
+
 DialogContent.defaultProps = {
-	dividers:false
-}
+  dividers: false,
+};
 export default DialogContent;

--- a/src/components/Dialogue/DialogContent.tsx
+++ b/src/components/Dialogue/DialogContent.tsx
@@ -12,4 +12,8 @@ const { children, className } = props;
 if(className) classes += ' ' + className;
 	return <div className={classes}>{children}</div>
 }
+
+DialogContent.defaultProps = {
+	dividers:false
+}
 export default DialogContent;

--- a/src/components/Dialogue/DialogContent.tsx
+++ b/src/components/Dialogue/DialogContent.tsx
@@ -11,7 +11,7 @@ let classes = 'dialog__content';
 const { dividers, children, className } = props;
 if(className) classes += ' ' + className;
 	return dividers ? 
-	(<div className={classes} data-testid='dialog-content-element'><hr/>{children}<hr/></div>) :
+	(<div className={classes} data-testid='dialog-content-element'><hr />{children}<hr /></div>) :
 	(<div className={classes} data-testid='dialog-content-element'>{children}</div>)
 }
 

--- a/src/components/Dialogue/DialogContent.tsx
+++ b/src/components/Dialogue/DialogContent.tsx
@@ -1,0 +1,15 @@
+import React, { FC } from 'react';
+export interface IDialogContentProps{
+	/** set style classes*/
+	className?:string;
+	/** set dividers option */
+	dividers?:boolean;
+}
+export type PatDialogContentProps = IDialogContentProps
+const DialogContent:FC<PatDialogContentProps> = (props)=>{
+let classes = 'dialog__content';
+const { children, className } = props;
+if(className) classes += ' ' + className;
+	return <div className={classes}>{children}</div>
+}
+export default DialogContent;

--- a/src/components/Dialogue/DialogContentText.tsx
+++ b/src/components/Dialogue/DialogContentText.tsx
@@ -8,6 +8,6 @@ const DialogContentText:FC<PatDialogContentTextProps> = (props)=>{
 let classes = 'dialog__content-text';
 const { children, className } = props;
 if(className) classes += ' ' + className;
-	return <div className={classes}>{children}</div>
+	return <div className={classes} data-testid='dialog-contenttext-element'>{children}</div>
 }
 export default DialogContentText;

--- a/src/components/Dialogue/DialogContentText.tsx
+++ b/src/components/Dialogue/DialogContentText.tsx
@@ -8,6 +8,7 @@ const DialogContentText:FC<PatDialogContentTextProps> = (props)=>{
 let classes = 'dialog__content-text';
 const { children, className } = props;
 if(className) classes += ' ' + className;
+	
 	return <div className={classes} data-testid='dialog-contenttext-element'>{children}</div>
 }
 export default DialogContentText;

--- a/src/components/Dialogue/DialogContentText.tsx
+++ b/src/components/Dialogue/DialogContentText.tsx
@@ -1,14 +1,19 @@
-import React, { FC } from 'react';
-export interface IDialogContentTextProps{
-	/** set style classes*/
-	className?:string;
+import React, { FC, HTMLAttributes } from 'react';
+export interface IDialogContentTextProps {
+  /** set style classes*/
+  className?: string;
 }
-export type PatDialogContentTextProps = IDialogContentTextProps
-const DialogContentText:FC<PatDialogContentTextProps> = (props)=>{
-let classes = 'dialog__content-text';
-const { children, className } = props;
-if(className) classes += ' ' + className;
-	
-	return <div className={classes} data-testid='dialog-contenttext-element'>{children}</div>
-}
+export type PatDialogContentTextProps = IDialogContentTextProps &
+  HTMLAttributes<HTMLDivElement>;
+const DialogContentText: FC<PatDialogContentTextProps> = (props) => {
+  let classes = 'dialog__content-text';
+  const { children, className } = props;
+  if (className) classes += ' ' + className;
+
+  return (
+    <div className={classes} data-testid="dialog-contenttext-element">
+      {children}
+    </div>
+  );
+};
 export default DialogContentText;

--- a/src/components/Dialogue/DialogContentText.tsx
+++ b/src/components/Dialogue/DialogContentText.tsx
@@ -1,0 +1,13 @@
+import React, { FC } from 'react';
+export interface IDialogContentTextProps{
+	/** set style classes*/
+	className?:string;
+}
+export type PatDialogContentTextProps = IDialogContentTextProps
+const DialogContentText:FC<PatDialogContentTextProps> = (props)=>{
+let classes = 'dialog__content-text';
+const { children, className } = props;
+if(className) classes += ' ' + className;
+	return <div className={classes}>{children}</div>
+}
+export default DialogContentText;

--- a/src/components/Dialogue/DialogTitle.tsx
+++ b/src/components/Dialogue/DialogTitle.tsx
@@ -13,6 +13,6 @@ export type PatDialogTitleProps = IDialogTitleProps
  */
 const DialogTitle:FC<PatDialogTitleProps> = (props)=>{
 	const { children, className } = props;
-	return <div className={`dialog__title `+className}>{children}</div>
+	return <div className={`dialog__title `+className} data-testid='dialog-title-element'>{children}</div>
 }
 export default DialogTitle;

--- a/src/components/Dialogue/DialogTitle.tsx
+++ b/src/components/Dialogue/DialogTitle.tsx
@@ -4,8 +4,15 @@ export interface IDialogTitleProps{
 	className?:string;
 }
 export type PatDialogTitleProps = IDialogTitleProps
+/**
+ * Dialog Title can be used in a Dialog to alert users
+ *
+ * ```js
+ * import { DialogTitle } from 'pat-ui'
+ * ```
+ */
 const DialogTitle:FC<PatDialogTitleProps> = (props)=>{
 	const { children, className } = props;
-	return <h1>{children}</h1>
+	return <div className={`dialog__title `+className}>{children}</div>
 }
 export default DialogTitle;

--- a/src/components/Dialogue/DialogTitle.tsx
+++ b/src/components/Dialogue/DialogTitle.tsx
@@ -5,7 +5,7 @@ export interface IDialogTitleProps{
 }
 export type PatDialogTitleProps = IDialogTitleProps
 const DialogTitle:FC<PatDialogTitleProps> = (props)=>{
-const { children, className } = props;
+	const { children, className } = props;
 	return <h1>{children}</h1>
 }
 export default DialogTitle;

--- a/src/components/Dialogue/DialogTitle.tsx
+++ b/src/components/Dialogue/DialogTitle.tsx
@@ -13,6 +13,11 @@ export type PatDialogTitleProps = IDialogTitleProps
  */
 const DialogTitle:FC<PatDialogTitleProps> = (props)=>{
 	const { children, className } = props;
-	return <div className={`dialog__title `+className} data-testid='dialog-title-element'>{children}</div>
+  let classes;
+  if(className) {
+    classes = `dialog__title `+className;
+  }
+  else classes='dialog__title';
+	return <div className={classes} data-testid='dialog-title-element'>{children}</div>
 }
 export default DialogTitle;

--- a/src/components/Dialogue/DialogTitle.tsx
+++ b/src/components/Dialogue/DialogTitle.tsx
@@ -1,9 +1,10 @@
-import React, { FC } from 'react';
-export interface IDialogTitleProps{
-	/** set style classes*/
-	className?:string;
+import React, { FC, HTMLAttributes } from 'react';
+export interface IDialogTitleProps {
+  /** set style classes*/
+  className?: string;
 }
-export type PatDialogTitleProps = IDialogTitleProps
+export type PatDialogTitleProps = IDialogTitleProps &
+  HTMLAttributes<HTMLDivElement>;
 /**
  * Dialog Title can be used in a Dialog to alert users
  *
@@ -11,13 +12,16 @@ export type PatDialogTitleProps = IDialogTitleProps
  * import { DialogTitle } from 'pat-ui'
  * ```
  */
-const DialogTitle:FC<PatDialogTitleProps> = (props)=>{
-	const { children, className } = props;
+const DialogTitle: FC<PatDialogTitleProps> = (props) => {
+  const { children, className } = props;
   let classes;
-  if(className) {
-    classes = `dialog__title `+className;
-  }
-  else classes='dialog__title';
-	return <div className={classes} data-testid='dialog-title-element'>{children}</div>
-}
+  if (className) {
+    classes = 'dialog__title ' + className;
+  } else classes = 'dialog__title';
+  return (
+    <div className={classes} data-testid="dialog-title-element">
+      {children}
+    </div>
+  );
+};
 export default DialogTitle;

--- a/src/components/Dialogue/DialogTitle.tsx
+++ b/src/components/Dialogue/DialogTitle.tsx
@@ -1,0 +1,11 @@
+import React, { FC } from 'react';
+export interface IDialogTitleProps{
+	/** set style classes*/
+	className?:string;
+}
+export type PatDialogTitleProps = IDialogTitleProps
+const DialogTitle:FC<PatDialogTitleProps> = (props)=>{
+const { children, className } = props;
+	return <h1>{children}</h1>
+}
+export default DialogTitle;

--- a/src/components/Dialogue/_Dialog.scss
+++ b/src/components/Dialogue/_Dialog.scss
@@ -8,3 +8,9 @@
   background-color: rgb(0, 0, 0); /* Fallback color */
   background-color: rgba(0, 0, 0, 0.4); /* Black w/ opacity */
 }
+.dialog__content{
+  margin: 50% auto;
+  width: 50%;
+  background-color:white;
+  padding:1em;
+}

--- a/src/components/Dialogue/_Dialog.scss
+++ b/src/components/Dialogue/_Dialog.scss
@@ -9,10 +9,10 @@
   background-color: rgb(0, 0, 0); /* Fallback color */
   background-color: rgba(0, 0, 0, 0.4); /* Black w/ opacity */
 }
-.dialog__content{
-  margin: 15% auto;
-  width:fit-content;
+.dialog__body{
+  margin: 5% auto;
   overflow:hidden;
   background-color:white;
   padding:1em;
+  border-radius:4px;
 }

--- a/src/components/Dialogue/_Dialog.scss
+++ b/src/components/Dialogue/_Dialog.scss
@@ -3,14 +3,16 @@
   z-index: 1; /* Sit on top */
   left: 0;
   top: 0;
+  overflow:hidden;
   width: 100%; /* Full width */
   height: 100%; /* Full height */
   background-color: rgb(0, 0, 0); /* Fallback color */
   background-color: rgba(0, 0, 0, 0.4); /* Black w/ opacity */
 }
 .dialog__content{
-  margin: 50% auto;
-  width: 50%;
+  margin: 15% auto;
+  width:fit-content;
+  overflow:hidden;
   background-color:white;
   padding:1em;
 }

--- a/src/components/Dialogue/_Dialog.scss
+++ b/src/components/Dialogue/_Dialog.scss
@@ -3,16 +3,53 @@
   z-index: 1; /* Sit on top */
   left: 0;
   top: 0;
-  overflow:hidden;
   width: 100%; /* Full width */
   height: 100%; /* Full height */
-  background-color: rgb(0, 0, 0); /* Fallback color */
-  background-color: rgba(0, 0, 0, 0.4); /* Black w/ opacity */
+  background-color: rgb(0, 0, 0);
+  background-color: rgba(0, 0, 0, 0.5); 
 }
 .dialog__body{
   margin: 5% auto;
-  overflow:hidden;
-  background-color:white;
+  width:50%;
+  top:10%;
+  left:10%;
+  background:$body-bg;
   padding:1em;
   border-radius:4px;
+  overflow-y:auto;
+  max-height:80vh;
+}
+.dialog__title{
+
+  margin-left:1.5em;
+  margin-top:1em;
+  margin-right:2.5em;
+  font-family: $font-family-base;
+  font-style: $headings-font-style;
+  font-weight: $headings-font-weight;
+  font-size: $font-size-lg;
+  line-height: $headings-line-height;
+  letter-spacing: 0.15px;
+  color: rgba(0, 0, 0, 0.87);
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+}
+
+.dialog__content{
+  display:flex;
+  flex-direction:column;
+  gap:1em;
+  margin-left:1.5em;
+  margin-right:2.5em;
+  margin-top:1em;
+  margin-bottom:1em;
+}
+.dialog__content-text{
+  color:$secondary;
+}
+.dialog__actions{
+  display:flex;
+  gap:1em;
+  justify-content:flex-end;
 }

--- a/src/components/Dialogue/_Dialog.scss
+++ b/src/components/Dialogue/_Dialog.scss
@@ -6,24 +6,23 @@
   width: 100%; /* Full width */
   height: 100%; /* Full height */
   background-color: rgb(0, 0, 0);
-  background-color: rgba(0, 0, 0, 0.5); 
+  background-color: rgba(0, 0, 0, 0.5);
 }
-.dialog__body{
+.dialog__body {
+  background: #ffffff;
+  border-radius: 4px;
   margin: 5% auto;
-  width:50%;
-  top:10%;
-  left:10%;
-  background:$body-bg;
-  padding:1em;
-  border-radius:4px;
-  overflow-y:auto;
-  max-height:80vh;
+  width: 50%;
+  top: 10%;
+  left: 10%;
+  padding: 1em;
+  overflow-y: auto;
+  max-height: 80vh;
 }
-.dialog__title{
-
-  margin-left:1.5em;
-  margin-top:1em;
-  margin-right:2.5em;
+.dialog__title {
+  margin-left: 1.5em;
+  margin-top: 1em;
+  margin-right: 2.5em;
   font-family: $font-family-base;
   font-style: $headings-font-style;
   font-weight: $headings-font-weight;
@@ -36,20 +35,48 @@
   flex-grow: 0;
 }
 
-.dialog__content{
-  display:flex;
-  flex-direction:column;
-  gap:1em;
-  margin-left:1.5em;
-  margin-right:2.5em;
-  margin-top:1em;
-  margin-bottom:1em;
+.dialog__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  margin-left: 1.5em;
+  margin-right: 2.5em;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  //styleName: typography / body1 ;
+  font-family: Roboto;
+  font-size: $font-size-base;
+  font-weight: font-weight-normal;
+  line-height: line-height-base;
+  letter-spacing: 0.15px;
+  text-align: left;
 }
-.dialog__content-text{
-  color:$secondary;
+.dialog-content-divider {
+  /* palette / divider */
+  background: #0000001f;
 }
-.dialog__actions{
-  display:flex;
-  gap:1em;
-  justify-content:flex-end;
+.dialog__content-text {
+  color: $secondary;
+}
+.dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+.--dialog__actions-gap {
+  gap: 1em;
+}
+.--dialog-body-max-width-xs {
+  max-width: 30%;
+}
+.--dialog-body-max-width-sm {
+  max-width: 40%;
+}
+.--dialog-body-max-width-md {
+  max-width: 50%;
+}
+.--dialog-body-max-width-lg {
+  max-width: 60%;
+}
+.--dialog-body-max-width-xl {
+  max-width: 70%;
 }

--- a/src/components/Dialogue/_Dialog.scss
+++ b/src/components/Dialogue/_Dialog.scss
@@ -7,6 +7,21 @@
   height: 100%; /* Full height */
   background-color: rgb(0, 0, 0);
   background-color: rgba(0, 0, 0, 0.5);
+  .--dialog-body-max-width-xs {
+    max-width: 30%;
+  }
+  .--dialog-body-max-width-sm {
+    max-width: 40%;
+  }
+  .--dialog-body-max-width-md {
+    max-width: 50%;
+  }
+  .--dialog-body-max-width-lg {
+    max-width: 60%;
+  }
+  .--dialog-body-max-width-xl {
+    max-width: 70%;
+  }
 }
 .dialog__body {
   background: #ffffff;
@@ -17,6 +32,7 @@
   left: 10%;
   padding: 1em;
   overflow-y: auto;
+
   max-height: 80vh;
 }
 .dialog__title {
@@ -64,19 +80,4 @@
 }
 .--dialog__actions-gap {
   gap: 1em;
-}
-.--dialog-body-max-width-xs {
-  max-width: 30%;
-}
-.--dialog-body-max-width-sm {
-  max-width: 40%;
-}
-.--dialog-body-max-width-md {
-  max-width: 50%;
-}
-.--dialog-body-max-width-lg {
-  max-width: 60%;
-}
-.--dialog-body-max-width-xl {
-  max-width: 70%;
 }

--- a/src/components/Dialogue/_Dialog.scss
+++ b/src/components/Dialogue/_Dialog.scss
@@ -1,0 +1,10 @@
+.dialog {
+  position: fixed; /* Stay in place */
+  z-index: 1; /* Sit on top */
+  left: 0;
+  top: 0;
+  width: 100%; /* Full width */
+  height: 100%; /* Full height */
+  background-color: rgb(0, 0, 0); /* Fallback color */
+  background-color: rgba(0, 0, 0, 0.4); /* Black w/ opacity */
+}

--- a/src/components/Dialogue/__snapshots__/Dialog.test.tsx.snap
+++ b/src/components/Dialogue/__snapshots__/Dialog.test.tsx.snap
@@ -1,11 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dialog Component should match snapshot 1`] = `
-<DocumentFragment>
-  <button
-    class="btn btn-default"
-  >
-     Snapshot Button 
-  </button>
-</DocumentFragment>
-`;
+exports[`Dialog Component and sub-components should match snapshot 1`] = `<DocumentFragment />`;

--- a/src/components/Dialogue/__snapshots__/Dialog.test.tsx.snap
+++ b/src/components/Dialogue/__snapshots__/Dialog.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dialog Component should match snapshot 1`] = `
+<DocumentFragment>
+  <button
+    class="btn btn-default"
+  >
+     Snapshot Button 
+  </button>
+</DocumentFragment>
+`;

--- a/src/components/Dialogue/__snapshots__/Dialog.test.tsx.snap
+++ b/src/components/Dialogue/__snapshots__/Dialog.test.tsx.snap
@@ -1,3 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Dialog Component and sub-components should match snapshot 1`] = `<DocumentFragment />`;
+exports[`Dialog Component and sub-components should match snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="dialog"
+    data-testid="dialog-element"
+  >
+    <div
+      class="dialog__body --dialog-body-max-width-sm"
+      data-testid="dialog-body-element"
+    >
+      <div
+        class="dialog__title"
+        data-testid="dialog-title-element"
+      >
+        Dialog Title
+      </div>
+      <div
+        class="dialog__content"
+        data-testid="dialog-content-element"
+      >
+        <div
+          class="dialog__content-text"
+          data-testid="dialog-contenttext-element"
+        >
+          Content Text
+        </div>
+        <div>
+          Content
+        </div>
+      </div>
+      <div
+        class="dialog__actions undefined --dialog__actions-gap"
+        data-testid="dialog-actions-element"
+      >
+        <button>
+          Button 1
+        </button>
+        <button>
+          Button 2
+        </button>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/Dialogue/index.tsx
+++ b/src/components/Dialogue/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Dialog';

--- a/src/components/Dialogue/index.tsx
+++ b/src/components/Dialogue/index.tsx
@@ -1,4 +1,5 @@
 export { default } from './Dialog';
 export { default } from './DialogTitle';
 export { default } from './DialogContent';
-import { default } from './DialogActions';
+export { default } from './DialogActions';
+export { default } from './DialogContentText';

--- a/src/components/Dialogue/index.tsx
+++ b/src/components/Dialogue/index.tsx
@@ -1,5 +1,5 @@
-export { default } from './Dialog';
-export { default } from './DialogTitle';
-export { default } from './DialogContent';
-export { default } from './DialogActions';
-export { default } from './DialogContentText';
+export { Dialog } from './Dialog';
+export { DialogTitle } from './DialogTitle';
+export { DialogContent } from './DialogContent';
+export { DialogActions } from './DialogActions';
+export { DialogContentText } from './DialogContentText';

--- a/src/components/Dialogue/index.tsx
+++ b/src/components/Dialogue/index.tsx
@@ -1,1 +1,4 @@
 export { default } from './Dialog';
+export { default } from './DialogTitle';
+export { default } from './DialogContent';
+import { default } from './DialogActions';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,3 +5,4 @@ export { default as Message } from './components/Message';
 export { default as Card } from './components/Card';
 export { default as Dropdown } from './components/Dropdown';
 export { default as Progress } from './components/Progress';
+export { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions } from './components/Dialogue';

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -12,3 +12,5 @@
 @import '../components/Input/Input';
 @import '../components/Card/Card';
 @import '../components/Progress/Progress';
+// Dialog
+@import '../components/Dialogue/Dialog';


### PR DESCRIPTION
- Mimics the UIUX of the MUI Dialog component
- Developers can provide title, content, actions of the dialog component from children props of the component
- Dialog component will have dimed backdrop by default, users can close the dialog by clicking on the backdrop
- Users shouldn’t be able to scroll the page when the dialog is open
- onClose callback function can be used to listen to close of the dialog.
- Open/Close of the dialog can be controlled from props.
- Adds following components - Dialog, DialogTitle, DialogContent, DialogContentText and DialogActions